### PR TITLE
Updated link to hardware status to Sigma2

### DIFF
--- a/news/news.rst
+++ b/news/news.rst
@@ -14,7 +14,7 @@ System status and activity
 --------------------------
 
 You can get a quick overview of the system load on Stallo on the
-`Notur hardware page <http://www.notur.no/hardware/status/>`_.
+`Sigma2 hardware page <https://www.sigma2.no/hardware/status>`_.
 More information on the system load, queued jobs, and node states can
 be found on the `jobbrowser page <http://stallo-login1.uit.no/jobbrowser/>`_
 (only visible from within the UiT network).


### PR DESCRIPTION
The Notur website is not updated anymore and sigma2 has the same info, so I updated the link to the hardware status.