### PR TITLE
update slurm examples with more specific allocation of resources

### DIFF
--- a/jobs/files/slurm-MPI-OMP.sh
+++ b/jobs/files/slurm-MPI-OMP.sh
@@ -6,9 +6,10 @@
 
 #SBATCH --job-name=example
 
-# we ask for 2 MPI tasks with 20 cores each
-#SBATCH --ntasks=2
-#SBATCH --cpus-per-task=20
+# we ask for 4 MPI tasks with 10 cores each
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=2
+#SBATCH --cpus-per-task=10
 
 # run for five minutes
 #              d-hh:mm:ss
@@ -39,7 +40,7 @@ cp ${SLURM_SUBMIT_DIR}/my_binary.x ${SCRATCH_DIRECTORY}
 export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK}
 
 # we execute the job and time it
-time ./my_binary.x > my_output
+time mpirun -np $SLURM_NTASKS ./my_binary.x > my_output
 
 # after the job is done we copy our output back to $SLURM_SUBMIT_DIR
 cp ${SCRATCH_DIRECTORY}/my_output ${SLURM_SUBMIT_DIR}

--- a/jobs/files/slurm-MPI.sh
+++ b/jobs/files/slurm-MPI.sh
@@ -37,7 +37,7 @@ cd ${SCRATCH_DIRECTORY}
 cp ${SLURM_SUBMIT_DIR}/my_binary.x ${SCRATCH_DIRECTORY}
 
 # we execute the job and time it
-time mpirun ./my_binary.x > my_output
+time mpirun -np $SLURM_NTASKS ./my_binary.x > my_output
 
 # after the job is done we copy our output back to $SLURM_SUBMIT_DIR
 cp ${SCRATCH_DIRECTORY}/my_output ${SLURM_SUBMIT_DIR}

--- a/jobs/files/slurm-OMP.sh
+++ b/jobs/files/slurm-OMP.sh
@@ -6,9 +6,10 @@
 
 #SBATCH --job-name=example
 
-# we ask for 1 node with 20 cores
+# we ask for 1 task with 20 cores
 #SBATCH --nodes=1
-#SBATCH --ntasks-per-node=20
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=20
 
 # run for five minutes
 #              d-hh:mm:ss
@@ -36,7 +37,7 @@ cd ${SCRATCH_DIRECTORY}
 cp ${SLURM_SUBMIT_DIR}/my_binary.x ${SCRATCH_DIRECTORY}
 
 # we set OMP_NUM_THREADS to the number of available cores
-export OMP_NUM_THREADS=${SLURM_TASKS_PER_NODE}
+export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK}
 
 # we execute the job and time it
 time ./my_binary.x > my_output


### PR DESCRIPTION
The concept of tasks vs. CPUs is a bit confusing in slurm, so I changed the examples so that tasks = MPI and CPUs = OpenMP. The old examples were not wrong, but somewhat confusing.