### PR TITLE
Replaced old notur email address with new metacenter address

### DIFF
--- a/account/uitquota.rst
+++ b/account/uitquota.rst
@@ -23,4 +23,4 @@ To get a local account on Stallo, you need to provide us with:
 
 **If you are a student, PhD or post-doc,** you need to also provide us with the name of your advisor and name of the project you are to be a member of.
 
-Compile this list in a proper manner and send to support-uit@notur.no.
+Compile this list in a proper manner and send to support-stallo@metacenter.no.

--- a/applications/chemistry/ADF/ADF.rst
+++ b/applications/chemistry/ADF/ADF.rst
@@ -39,9 +39,7 @@ Online info from vendor
 * Homepage: https://www.scm.com
 * Documentation: https://www.scm.com/doc
 
-The support people in NOTUR, do not provide trouble shooting guides anymore, due to a national agreement that it is better for the community as \
-a whole to add to the community info/knowledge pool  where such is made available. For ADF/BAND we advise to search in general documentation, se\
-nding emails to support(either notur or scm) or trying the ADF mailing list (see https://www.scm.com/Support for more info).
+The support people in NOTUR, do not provide trouble shooting guides anymore, due to a national agreement that it is better for the community as a whole to add to the community info/knowledge pool where such is made available. For ADF/BAND we advise to search in general documentation, sending emails to support (either metacenter or scm) or trying the ADF mailing list (see https://www.scm.com/Support for more info).
 
 
 License and access policy

--- a/applications/chemistry/Molcas/Molcas.rst
+++ b/applications/chemistry/Molcas/Molcas.rst
@@ -41,7 +41,7 @@ License and access policy
 Molcas comes with a non-free computer center license, though it is free for academic employees from the Nordic region.
 The HPC group @ UiT have an agreement with Molcas as a part of the old application management project, that we do make a central
 install of the code - but users who wants access needs to document that they have made an agreement with Molcas. This proof of agreement should
-then be mailed (e or non-e) to support-uit@notur.no to be granted membership of the molcas group on Stallo.
+then be mailed (e or non-e) to support-stallo@metacenter.no to be granted membership of the molcas group on Stallo.
 
 For the future, we are considering establishing the same policy as for :ref:`ORCA`, especially since the vendor has done a substantial job at decomplicating
 the install procedure using CMake.

--- a/applications/chemistry/Schrodinger/Schrodinger.rst
+++ b/applications/chemistry/Schrodinger/Schrodinger.rst
@@ -53,7 +53,7 @@ License and access policy
 
 The licenses of Schrödinger Product Suites are commercial.
 
-NOTUR is, together with the user community, funding a national license of Schrödinger´s Small Molecule Drug Discovery Suite and PyMol. The licenses are administered by a license server based on flexlm. The adress for this license setup is available upon request to support-uit(at)notur.no.
+NOTUR is, together with the user community, funding a national license of Schrödinger´s Small Molecule Drug Discovery Suite and PyMol. The licenses are administered by a license server based on flexlm. The adress for this license setup is available upon request to support-stallo@metacenter.no.
 
 The outtake of license tokens is monitored on regular basis, and we try to catch those who seems to use the suite for regular scientific production and ask them to contribute financially to the overall deal. So far, this policy have worked fairly well.
 

--- a/applications/chemistry/VASP/VASP.rst
+++ b/applications/chemistry/VASP/VASP.rst
@@ -45,8 +45,7 @@ The VASP license is proprietary and commercial. It is based on group license pol
 
 The Vasp program is not distributed via site licences. However, HPC-staff in NOTUR have access to the VASP code to be able to support any research groups that have a valid VASP license.
 
-VASP is a commercial software package that requires a license for all who wants to run on Stallo. To get access you would need to prove that the group you are a m\
-ember of holds a valid licence; a representative for the research group needs to contact VASP and ask for an aknowledgement of you connection to the license. A VASP representative sends this acknowledgement to support@notur.no. Then your name is put into the VASP group, granting you access to the VASP 5 release of VASP on Stallo.
+VASP is a commercial software package that requires a license for all who wants to run on Stallo. To get access you would need to prove that the group you are a member of holds a valid licence; a representative for the research group needs to contact VASP and ask for an aknowledgement of you connection to the license. A VASP representative sends this acknowledgement to support-stallo@metacenter.no. Then your name is put into the VASP group, granting you access to the VASP 5 release of VASP on Stallo.
 
 The support people in NOTUR, do not provide trouble shooting guides anymore, due to a national agreement that it is better for the community as a whole to add to the community info/knowledge pool where such is made available. Also, HPC staff from UiT does not provide any support to VASP 4 anymore, basically due to age of the code.
 

--- a/help/contact.rst
+++ b/help/contact.rst
@@ -3,12 +3,8 @@
 Contact
 =======
 
-If you need help, please file a support request via support-uit@notur.no, and
+If you need help, please file a support request via support-stallo@metacenter.no, and
 our local team of experts will try to assist you as soon as possible.
-
-Alternatively you can use https://support.notur.no to submit and track your requests.
-The necessary user name and password are generated the first time you
-send an email to support-uit@notur.no.
 
 .. image:: rtfm.png
 

--- a/help/writing-support-requests.rst
+++ b/help/writing-support-requests.rst
@@ -11,10 +11,10 @@ to resolve it faster. Below is a list of good practices.
 Never send support requests to staff members directly
 -----------------------------------------------------
 
-Always send them to support-uit@notur.no and staff members will pick them
-up there. On support-uit@notur.no they get tracked and have higher visibility.
+Always send them to support-stallo@metacenter.no and staff members will pick them
+up there. On support-stallo@metacenter.no they get tracked and have higher visibility.
 Some staff members work on the support line only part time.
-Sending the request to support-uit@notur.no makes sure that somebody will pick
+Sending the request to support-stallo@metacenter.no makes sure that somebody will pick
 it up.
 
 

--- a/jobs/batch.rst
+++ b/jobs/batch.rst
@@ -124,7 +124,7 @@ Resources
 QOS*Limit
   This should only happen if you run your job with ``--qos=devel``. In developer mode you may only have one single job in the queue.
 launch failed requeued held
-  Job launch failed for some reason. This is normally due to a faulty node. Please contact us via support-uit@notur.no stating the problem, your user name, and the jobid(s).
+  Job launch failed for some reason. This is normally due to a faulty node. Please contact us via support-stallo@metacenter.no stating the problem, your user name, and the jobid(s).
 Dependency
   Job cannot start before some other job is finished. This should only happen if you started the job with ``--dependency=...``
 DependencyNeverSatisfied

--- a/jobs/partitions.rst
+++ b/jobs/partitions.rst
@@ -53,8 +53,7 @@ General job limitations
 -----------------------
 
 The following limits are the default per user in the batch system. Users
-can ask for increased limits by sending a request to
-support-uit@notur.no.
+can ask for increased limits by sending a request to support-stallo@metacenter.no.
 
 ========================== ================
 Limit                      Value

--- a/software/applications.rst
+++ b/software/applications.rst
@@ -11,9 +11,9 @@ To find out what software packages are available, type::
 Missing or new software
 -----------------------
 
-If there is any SW missing on this list that you would like to have
-installed on Stallo, or you need help to install your own SW, please
-feel free to contact the support personal about this: support-uit@notur.no.
+If there is any software missing on this list that you would like to have
+installed on Stallo, or you need help to install your own software, please
+feel free to contact the support personal about this: support-stallo@metacenter.no.
 
 
 Changes in application software

--- a/stallo/getting_started.rst
+++ b/stallo/getting_started.rst
@@ -41,6 +41,6 @@ Every job that gets started will be charged to your quota. Your quota is calcula
 Get help
 --------
 
-Do you need help with Stallo? Write us an email to support-uit@notur.no. You can also request new software (either an update or entirely new software), suggest changes to this documentation, or send us any other suggestions or issues concerning Stallo to that email address. Please also read the rest of this documentation.
+Do you need help with Stallo? Write us an email to support-stallo@metacenter.no. You can also request new software (either an update or entirely new software), suggest changes to this documentation, or send us any other suggestions or issues concerning Stallo to that email address. Please also read the rest of this documentation.
 
 Happy researching!

--- a/storage/storage.rst
+++ b/storage/storage.rst
@@ -47,7 +47,7 @@ These work areas should be used for all jobs running on Stallo.
 
 There is no backup of files stored on the work areas.
 If you need permanent storage of large amounts of data, please
-contact the system administrators: support-uit@notur.no
+contact the system administrators: support-stallo@metacenter.no
 
 Disk quota is not enforced on work/scratch areas. Please use common courtesy
 and keep your work/scratch partitions clean. Move all files you do not need on
@@ -69,7 +69,7 @@ kept at /global/hds/.snapshot/
 There is no backup of files stored on the /global/work and /local/work areas.
 If you need permanent storage of large amounts of data, or if you need to
 restore some lost data, please contact the system administrators:
-support-uit@notur.no
+support-stallo@metacenter.no
 
 
 Archiving data


### PR DESCRIPTION
As discussed in the Thursday-morning-meeting, we now use the new email address support-stallo@metacenter.no