### PR TITLE
Move the quiet option up front in module purge

### DIFF
--- a/applications/chemistry/files/job_adf.sh
+++ b/applications/chemistry/files/job_adf.sh
@@ -31,7 +31,7 @@ cores=$SLURM_NTASKS  # Number of cores potentially used by mpi engine in submit 
 
 # We load all the default program system settings with module load:
 
-module purge --quiet
+module --quiet purge
 module load ADF/adf2017.108
 
 # Now we create working directory and temporary scratch for the job(s):

--- a/applications/chemistry/files/job_band.sh
+++ b/applications/chemistry/files/job_band.sh
@@ -32,7 +32,7 @@ cores=40  # Number of cores potentially used by mpi engine in submit procedure
 
 # We load all the default program system settings with module load:
 
-module purge --quiet
+module --quiet purge
 module load ADF/adf2017.108
 
 # Now we create working directory and temporary scratch for the job(s):

--- a/applications/chemistry/files/job_g09.sh
+++ b/applications/chemistry/files/job_g09.sh
@@ -29,7 +29,7 @@ ext=com # We use the same naming scheme as the software default extention
 
 # We load all the default program system settings with module load:
 
-module purge --quiet
+module --quiet purge
 module load Gaussian/09.d01
 
 # Now we create working directory and temporary scratch for the job(s):

--- a/applications/chemistry/files/job_molcas.sh
+++ b/applications/chemistry/files/job_molcas.sh
@@ -31,7 +31,7 @@ input=C2H6 # Name of job input
 
 # We load all the default program system settings with module load:
 
-module purge --quiet
+module --quiet purge
 module load Molcas/molcas82-intel-2015a
 # You may check other available versions with "module avail Molcas"
 

--- a/applications/chemistry/files/job_turbo.sh
+++ b/applications/chemistry/files/job_turbo.sh
@@ -15,7 +15,7 @@
 # --cpus-per-task   : always full nodes
 
 # load modules
-module purge --quiet
+module --quiet purge
 module load TURBOMOLE/7.2
 
 # TURBOMOLE needs this variable

--- a/applications/chemistry/files/job_vasp.sh
+++ b/applications/chemistry/files/job_vasp.sh
@@ -36,7 +36,7 @@ input=$(ls ${proj}/{INCAR,KPOINTS,POTCAR,POSCAR}) # Input files from job folder
 
 # We load all the default program system settings with module load:
 
-module purge --quiet
+module --quiet purge
 module load VASP/5.4.1.plain-intel-2016a
 # You may check other available versions with "module avail VASP"
 


### PR DESCRIPTION
`module purge --quiet` triggers a weird lmod bug that results in a forced purge (actually, `module purge donaldtrump` has the same effect). Interestingly though, `ml purge --quiet` seems to work as expected...